### PR TITLE
Forzar con la versión especifica

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ android {
 // force this specific version so gradle doesn't complain about mixed versions (caused by Facebook SDK)
 configurations.all {
     resolutionStrategy {
-        force 'com.android.support:appcompat-v7:26.+'
+        force 'com.android.support:appcompat-v7:26.0.1'
     }
 }
 


### PR DESCRIPTION
Si no coinciden las versiones genera un error cuando el proyecto hace un build. En este momento ya hay una versión 26.0.2 que entra dentro del rango 26.+